### PR TITLE
chore: update development dependencies and CI actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       COVERAGE: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - run: rm -f Gemfile.lock
 
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: ${{ matrix.ruby_version == 'ruby-head' || matrix.actionview_version == 'edge' }}
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: svyatov/clsx-rails

--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,10 @@ else
   gem 'actionview'
 end
 
-gem 'benchmark-ips', '~> 2.14'
+gem 'benchmark-ips', '~> 2.15'
 gem 'minitest', '~> 6.0'
-gem 'rake', '~> 13.2'
-gem 'rubocop', '~> 1.81'
+gem 'rake', '~> 13.4'
+gem 'rubocop', '~> 1.88'
 gem 'tailwind_merge'
 
 gem 'simplecov', require: false


### PR DESCRIPTION
Routine dependency refresh. No runtime dependency or public API changes.

- Raise Gemfile floors: `rubocop ~> 1.88`, `rake ~> 13.4`, `benchmark-ips ~> 2.15`.
- Bump `actions/checkout` v4 to v7 and `codecov/codecov-action` v5 to v7. Both majors require a runner with Node 24, which `ubuntu-latest` provides.

`Gemfile.lock` is gitignored, so the resolved bumps are not in the diff. Locally `bundle update` also moved simplecov 0.22.0 to 1.0.3 and simplecov-cobertura 3.1.0 to 4.0.0. Neither is constrained in the Gemfile, so CI resolves the same versions. Coverage reporting still works with both.

`bundle exec rake` passes: 8 runs, 10 assertions, 0 failures, RuboCop clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build and code coverage workflows to use newer tooling versions.
  - Refreshed development tooling configurations to support more consistent code quality checks and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->